### PR TITLE
Add groups table. 

### DIFF
--- a/deploy/groups.sql
+++ b/deploy/groups.sql
@@ -1,0 +1,28 @@
+-- Deploy groups
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS groups(
+  id VARCHAR(36) PRIMARY KEY,
+
+-- We may wish to allow 'null' org_ids in the future to represent
+-- global groups (organizations and users). Otherwise we should
+-- reserve a GUID or GUID range to represent global groups. (One
+-- possibility would be to examine the UUID generation process, and
+-- ensure that a certain UUID could never be generated normally) Or we
+-- could try to insure we never collide at id creation time, but
+-- adding a check for an extraordinarly rare chance of collision seems
+-- silly. Or we could just create a dummy org !EC_GLOBALS with a name
+-- that we disallow for users and use that. That org should have a
+-- notable GUID such as all '0' or the like
+
+  org_id CHAR(32) NOT NULL,
+  authz_id CHAR(32) NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  CONSTRAINT groups_org_id_name_key UNIQUE(org_id, name),
+  last_updated_by CHAR(32) NOT NULL,
+  created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL
+);
+
+COMMIT;

--- a/revert/groups.sql
+++ b/revert/groups.sql
@@ -1,0 +1,7 @@
+-- Revert groups
+
+BEGIN;
+
+DROP TABLE if EXISTS groups;
+
+COMMIT;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -17,3 +17,5 @@ containers 2013-09-23T17:46:57Z Mark Anderson <mark@opscode.com> # Add container
 password_hash_type 2013-09-24T14:29:08Z Marc Paradise <marc@opscode.com> # new enum for supported password hash types
 users_password_hash_split [users] 2013-09-24T14:42:14Z Marc Paradise <marc@opscode.com># add columns to user that split out password hash and salt
 @2.1.0 2013-09-25T01:26:17Z Marc Paradise <marc@alienix># 2.1.0 - to be synced with release tag
+groups 2013-09-23T18:21:28Z Mark Anderson <mark@opscode.com> # Add groups in sql
+@2.2.0 2013-09-25T05:53:40Z Mark Anderson <mark@opscode.com> # Add groups in sql

--- a/t/monkey_patches.sql
+++ b/t/monkey_patches.sql
@@ -20,7 +20,8 @@ AS $$
          (p_table_name = 'data_bags' AND p_column_name = 'id') OR
          (p_table_name = 'roles' AND p_column_name = 'id') OR
          (p_table_name = 'environments' AND p_column_name = 'id') OR
-	 (p_table_name = 'containers' AND p_column_name = 'id')
+	 (p_table_name = 'containers' AND p_column_name = 'id') OR
+	 (p_table_name = 'groups' AND p_column_name = 'id')
 $$;
 
 CREATE OR REPLACE FUNCTION chef_pgtap.col_is_uuid(p_table_name NAME, p_column_name NAME, p_is_unique BOOLEAN)

--- a/t/test_groups_table.sql
+++ b/t/test_groups_table.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION test_groups_table()
+RETURNS SETOF TEXT
+LANGUAGE plpgsql
+AS $$
+BEGIN
+
+  RETURN QUERY SELECT has_table('groups');
+
+  -- Columns
+
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('groups', 'id');
+  RETURN QUERY SELECT col_is_pk('groups', 'id');
+
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('groups', 'authz_id', TRUE);
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('data_bags', 'org_id');
+
+  RETURN QUERY SELECT chef_pgtap.col_is_name('groups', 'name');
+
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('groups', 'last_updated_by');
+  RETURN QUERY SELECT chef_pgtap.col_is_timestamp('groups', 'created_at');
+  RETURN QUERY SELECT chef_pgtap.col_is_timestamp('groups', 'updated_at');
+
+  RETURN QUERY SELECT col_is_unique('groups', ARRAY['org_id', 'name']);
+
+  -- Indexes
+
+  RETURN QUERY SELECT chef_pgtap.has_index('groups', 'groups_authz_id_key', 'authz_id');
+  RETURN QUERY SELECT chef_pgtap.has_index('groups', 'groups_org_id_name_key', ARRAY['org_id', 'name']);
+
+  -- Keys
+
+  RETURN QUERY SELECT has_pk('groups');
+  RETURN QUERY SELECT hasnt_fk('groups');
+
+END;
+$$;

--- a/verify/groups.sql
+++ b/verify/groups.sql
@@ -1,0 +1,10 @@
+-- Verify groups
+
+BEGIN;
+
+SELECT id, org_id, authz_id, name, 
+       last_updated_by, created_at, updated_at
+FROM groups
+WHERE FALSE;
+
+ROLLBACK;


### PR DESCRIPTION
@seth @sdelano @marcparadise @hosh 

Add groups table.

This is nearly identical to the containers table work.

Groups are authorization objects, so they go here, instead of in
chef-server-schema.

This deliberately follows the last_updated_by, created_at, update_at
pattern of other objects like roles and containers, even though they
don't actually get updated. While not particularly useful, keeping all
objects with an authz_id similar simplifies a lot of code.

Included tests for groups table; required updating monkey patch
code to allow id to be VARCHAR(36)
