### PR TITLE
Drop the reporting schema info table that isn't needed

### DIFF
--- a/deploy/drop_reporting_schema_info.sql
+++ b/deploy/drop_reporting_schema_info.sql
@@ -1,0 +1,8 @@
+-- Deploy drop_reporting_schema_info
+-- requires: reporting_schema_info
+
+BEGIN;
+
+DROP TABLE IF EXISTS reporting_schema_info;
+
+COMMIT;

--- a/revert/drop_reporting_schema_info.sql
+++ b/revert/drop_reporting_schema_info.sql
@@ -1,0 +1,9 @@
+-- Revert drop_reporting_schema_info
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS reporting_schema_info(
+  version INTEGER NOT NULL DEFAULT 0
+);
+
+COMMIT;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -24,3 +24,5 @@ groups 2013-09-23T18:21:28Z Mark Anderson <mark@opscode.com> # Add groups in sql
 opc_users_customer_id_index [opc_users] 2013-10-09T14:09:35Z Oliver Ferrigni <oliver@opscode.com># Add index opc_users(customer_id)
 @2.2.2 2013-10-10T18:28:40Z Oliver Ferrigni <oliver@opscode.com># Tag with 2.2.2
 @2.2.3 2013-10-14T20:26:26Z Oliver Ferrigni <oliver@opscode.com># Makefile updates
+
+drop_reporting_schema_info [reporting_schema_info] 2014-01-08T22:04:01Z Mark Mzyk <mmzyk@opscode.com> # Drop reporting_schema_info table that is not needed

--- a/verify/drop_reporting_schema_info.sql
+++ b/verify/drop_reporting_schema_info.sql
@@ -1,0 +1,7 @@
+-- Verify drop_reporting_schema_info
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
Saw this table and it appears to be a vestige left over from the old reporting system. This PR just uses sqitch to drop it. I have not tested this, but thought I'd be nice and put the code up here for the team working on this.

@seth @christophermaier and @marcparadise should probably verify that in fact this table isn't needed.
