### PR TITLE
Create default key on update if it doesn't exist

### DIFF
--- a/sqitch.plan
+++ b/sqitch.plan
@@ -46,6 +46,7 @@ multiple_keys 2014-12-29T23:45:05Z Mark Anderson <mark@chef.io> # Add keys table
 keys_drop_trigger 2015-01-03T01:25:39Z Mark Anderson <mark@chef.io># Keys table drop trigger to maintain consistency
 keys_update_trigger 2015-01-03T01:33:03Z Mark Anderson <mark@chef.io># Triggers to keep keys table consistient with clients and users tables.
 multiple_keys_migration 2015-01-03T02:29:48Z Mark Anderson <mark@chef.io># Add migration code to populate keys table
-@2.5.0 2015-01-14T20:09:20Z Marc Paradise <marc@chef.io> #  Tag with 2.5.0
+@2.5.0 2015-01-14T20:09:20Z Marc Paradise <marc@chef.io> # Tag with 2.5.0
 @2.5.1 2015-01-19T19:01:54Z Steven Danna <steve@chef.io> # Add COMMIT to multiple_keys_migration
 @2.5.2 2015-01-20T23:03:35Z Marc Paradise <marc@chef.io> # Tag with 2.5.2 for expire_at on key view
+@2.5.3 2015-01-23T15:43:00Z Marc Paradise <marc@chef.io> # Modify client/user update trigger to insert missing default key


### PR DESCRIPTION
If a default key isn't present during update of a user/client key, add it. 
ping @chef/lob 