### PR TITLE
Adding required tables for the new cookbook_artifacts endpoint

### DIFF
--- a/deploy/cookbook_artifact_version_checksums.sql
+++ b/deploy/cookbook_artifact_version_checksums.sql
@@ -1,0 +1,23 @@
+-- Deploy cookbook_artifact_version_checksums
+-- requires: cookbook_artifact_versions
+-- requires: checksums
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS cookbook_artifact_version_checksums(
+  cookbook_artifact_version_id CHAR(32) NOT NULL REFERENCES cookbook_artifact_versions(id),
+  org_id CHAR(32) NOT NULL,
+  checksum CHAR(32) NOT NULL,
+  FOREIGN KEY (org_id, checksum)
+    REFERENCES checksums(org_id, checksum)
+    ON DELETE RESTRICT
+    ON UPDATE CASCADE
+);
+
+CREATE INDEX cookbook_artifact_version_checksums_by_id
+  ON cookbook_artifact_version_checksums(cookbook_artifact_version_id);
+
+CREATE INDEX cookbook_artifact_version_checksums_by_org_id_checksum
+  ON cookbook_artifact_version_checksums(org_id, checksum);
+
+COMMIT;

--- a/deploy/cookbook_artifact_versions.sql
+++ b/deploy/cookbook_artifact_versions.sql
@@ -1,0 +1,25 @@
+-- Deploy cookbook_artifact_versions
+-- requires: cookbook_artifacts
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS cookbook_artifact_versions(
+  id CHAR(32) PRIMARY KEY,
+  identifier VARCHAR(255) NOT NULL,
+  meta_attributes bytea NOT NULL,
+  meta_long_desc bytea NOT NULL,
+  metadata bytea NOT NULL,
+  serialized_object bytea NOT NULL,
+  updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  last_updated_by CHAR(32) NOT NULL,
+  cookbook_id INTEGER NOT NULL REFERENCES cookbooks(id) ON DELETE RESTRICT,
+  UNIQUE(cookbook_id, identifier)
+);
+
+ALTER TABLE cookbook_artifact_versions ALTER meta_attributes SET STORAGE EXTERNAL;
+ALTER TABLE cookbook_artifact_versions ALTER meta_long_desc SET STORAGE EXTERNAL;
+ALTER TABLE cookbook_artifact_versions ALTER metadata SET STORAGE EXTERNAL;
+ALTER TABLE cookbook_artifact_versions ALTER serialized_object SET STORAGE EXTERNAL;
+
+COMMIT;

--- a/deploy/cookbook_artifacts.sql
+++ b/deploy/cookbook_artifacts.sql
@@ -1,0 +1,15 @@
+-- Deploy cookbook_artifacts
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS cookbook_artifacts(
+  id SERIAL PRIMARY KEY,
+  org_id CHAR(32) NOT NULL,
+  name TEXT NOT NULL,
+  UNIQUE(org_id, name),
+  authz_id CHAR(32) NOT NULL UNIQUE
+);
+
+CREATE INDEX cookbook_artifacts_org_id_index ON cookbook_artifacts(org_id);
+
+COMMIT;

--- a/revert/cookbook_artifact_version_checksums.sql
+++ b/revert/cookbook_artifact_version_checksums.sql
@@ -1,0 +1,7 @@
+-- Revert cookbook_artifact_version_checksums
+
+BEGIN;
+
+DROP TABLE IF EXISTS cookbook_artifact_version_checksums;
+
+COMMIT;

--- a/revert/cookbook_artifact_versions.sql
+++ b/revert/cookbook_artifact_versions.sql
@@ -1,0 +1,7 @@
+-- Revert cookbook_artifact_versions
+
+BEGIN;
+
+DROP TABLE IF EXISTS cookbook_artifact_versions;
+
+COMMIT;

--- a/revert/cookbook_artifacts.sql
+++ b/revert/cookbook_artifacts.sql
@@ -1,0 +1,7 @@
+-- Revert cookbook_artifacts
+
+BEGIN;
+
+DROP TABLE IF EXISTS cookbook_artifacts;
+
+COMMIT;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -50,3 +50,8 @@ multiple_keys_migration 2015-01-03T02:29:48Z Mark Anderson <mark@chef.io># Add m
 @2.5.1 2015-01-19T19:01:54Z Steven Danna <steve@chef.io> # Add COMMIT to multiple_keys_migration
 @2.5.2 2015-01-20T23:03:35Z Marc Paradise <marc@chef.io> # Tag with 2.5.2 for expire_at on key view
 @2.5.3 2015-01-23T15:43:00Z Marc Paradise <marc@chef.io> # Modify client/user update trigger to insert missing default key
+
+cookbook_artifacts 2015-02-03T17:34:42Z Jean Rouge <jean@chef.io> # Creating cookbook_artifacts tables
+cookbook_artifact_versions [cookbook_artifacts] 2015-02-03T17:34:42Z Jean Rouge <jean@chef.io> # Creating cookbook_artifacts tables
+cookbook_artifact_version_checksums [cookbook_artifact_versions] 2015-02-03T17:34:42Z Jean Rouge <jean@chef.io> # Creating cookbook_artifacts tables
+@2.6.0 2015-02-03T20:02:46Z Jean Rouge <jean@chef.io> # Tagging with 2.6.0

--- a/t/test_cookbook_artifact_version_checksums_table.sql
+++ b/t/test_cookbook_artifact_version_checksums_table.sql
@@ -1,0 +1,41 @@
+CREATE OR REPLACE FUNCTION test_cookbook_artifact_version_checksums_table()
+RETURNS SETOF TEXT
+LANGUAGE plpgsql
+AS $$
+BEGIN
+
+  RETURN QUERY SELECT has_table('cookbook_artifact_version_checksums');
+
+  -- Columns
+  RETURN QUERY SELECT columns_are('cookbook_artifact_version_checksums', ARRAY['cookbook_artifact_version_id',
+                                                                               'org_id',
+                                                                               'checksum']);
+
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('cookbook_artifact_version_checksums', 'cookbook_artifact_version_id');
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('cookbook_artifact_version_checksums', 'org_id');
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('cookbook_artifact_version_checksums', 'checksum');
+
+  -- Indexes
+  RETURN QUERY SELECT chef_pgtap.has_index('cookbook_artifact_version_checksums',
+                                           'cookbook_artifact_version_checksums_by_id',
+                                           'cookbook_artifact_version_id');
+  RETURN QUERY SELECT chef_pgtap.has_index('cookbook_artifact_version_checksums',
+                                           'cookbook_artifact_version_checksums_by_org_id_checksum',
+                                           ARRAY['org_id', 'checksum']);
+
+  -- Keys
+  RETURN QUERY SELECT fk_ok('cookbook_artifact_version_checksums', 'cookbook_artifact_version_id',
+                            'cookbook_artifact_versions', 'id');
+  RETURN QUERY SELECT chef_pgtap.fk_update_action_is('cookbook_artifact_version_checksums_cookbook_artifact_version_id_fkey', 'NO ACTION');
+  RETURN QUERY SELECT chef_pgtap.fk_delete_action_is('cookbook_artifact_version_checksums_cookbook_artifact_version_id_fkey', 'NO ACTION');
+
+  RETURN QUERY SELECT fk_ok('cookbook_artifact_version_checksums',
+                            ARRAY['org_id', 'checksum'],
+                            'checksums',
+                            ARRAY['org_id', 'checksum']);
+
+  RETURN QUERY SELECT chef_pgtap.fk_update_action_is('cookbook_artifact_version_checksums_org_id_fkey', 'CASCADE');
+  RETURN QUERY SELECT chef_pgtap.fk_delete_action_is('cookbook_artifact_version_checksums_org_id_fkey', 'RESTRICT');
+
+END;
+$$;

--- a/t/test_cookbook_artifact_versions_table.sql
+++ b/t/test_cookbook_artifact_versions_table.sql
@@ -1,0 +1,51 @@
+CREATE OR REPLACE FUNCTION test_cookbook_artifact_versions_table()
+RETURNS SETOF TEXT
+LANGUAGE plpgsql
+AS $$
+BEGIN
+
+  RETURN QUERY SELECT has_table('cookbook_artifact_versions');
+
+  -- Columns
+  RETURN QUERY SELECT columns_are('cookbook_artifact_versions', ARRAY['id',
+                                                                      'identifier',
+                                                                      'meta_attributes',
+                                                                      'meta_long_desc',
+                                                                      'metadata',
+                                                                      'serialized_object',
+                                                                      'updated_at',
+                                                                      'created_at',
+                                                                      'last_updated_by',
+                                                                      'cookbook_id']);
+
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('cookbook_artifact_versions', 'id');
+  RETURN QUERY SELECT col_is_pk('cookbook_artifact_versions', 'id');
+
+  RETURN QUERY SELECT chef_pgtap.col_is_blob('cookbook_artifact_versions', 'meta_attributes');
+  RETURN QUERY SELECT chef_pgtap.col_is_blob('cookbook_artifact_versions', 'metadata');
+  RETURN QUERY SELECT chef_pgtap.col_is_blob('cookbook_artifact_versions', 'serialized_object');
+  RETURN QUERY SELECT chef_pgtap.col_is_timestamp('cookbook_artifact_versions', 'updated_at');
+  RETURN QUERY SELECT chef_pgtap.col_is_timestamp('cookbook_artifact_versions', 'created_at');
+
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('cookbook_artifact_versions', 'last_updated_by');
+
+  RETURN QUERY SELECT col_not_null('cookbook_artifact_versions', 'cookbook_id');
+  RETURN QUERY SELECT col_type_is('cookbook_artifact_versions', 'cookbook_id', 'integer');
+  RETURN QUERY SELECT col_hasnt_default('cookbook_artifact_versions', 'cookbook_id');
+
+
+  -- Indexes
+  RETURN QUERY SELECT col_is_unique('cookbook_artifact_versions',
+                                     ARRAY['cookbook_id', 'identifier']);
+
+  -- Keys
+  RETURN QUERY SELECT has_pk('cookbook_artifact_versions');
+  RETURN QUERY SELECT has_fk('cookbook_artifact_versions');
+
+  RETURN QUERY SELECT fk_ok('cookbook_artifact_versions', 'cookbook_id',
+                            'cookbooks', 'id');
+  RETURN QUERY SELECT chef_pgtap.fk_update_action_is('cookbook_artifact_versions_cookbook_id_fkey', 'NO ACTION');
+  RETURN QUERY SELECT chef_pgtap.fk_delete_action_is('cookbook_artifact_versions_cookbook_id_fkey', 'RESTRICT');
+
+END;
+$$;

--- a/t/test_cookbook_artifacts_table.sql
+++ b/t/test_cookbook_artifacts_table.sql
@@ -1,0 +1,34 @@
+CREATE OR REPLACE FUNCTION test_cookbook_artifacts_table()
+RETURNS SETOF TEXT
+LANGUAGE plpgsql
+AS $$
+BEGIN
+
+  RETURN QUERY SELECT has_table('cookbook_artifacts');
+
+  -- Columns
+  RETURN QUERY SELECT columns_are('cookbook_artifacts', ARRAY['id',
+                                                              'org_id',
+                                                              'name',
+                                                              'authz_id']);
+  RETURN QUERY SELECT col_not_null('cookbook_artifacts', 'id');
+  RETURN QUERY SELECT col_type_is('cookbook_artifacts', 'id', 'integer');
+  RETURN QUERY SELECT col_has_default('cookbook_artifacts', 'id');
+  RETURN QUERY SELECT col_default_is('cookbook_artifacts', 'id', 'nextval(''cookbook_artifacts_id_seq''::regclass)');
+
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('cookbook_artifacts', 'org_id');
+  RETURN QUERY SELECT chef_pgtap.col_is_name('cookbook_artifacts', 'name');
+  RETURN QUERY SELECT chef_pgtap.col_is_uuid('cookbook_artifacts', 'authz_id', TRUE);
+
+  RETURN QUERY SELECT col_is_pk('cookbooks', 'id');
+
+  -- Indexes
+  RETURN QUERY SELECT chef_pgtap.has_index('cookbook_artifacts', 'cookbook_artifacts_authz_id_key', 'authz_id');
+  RETURN QUERY SELECT chef_pgtap.has_index('cookbook_artifacts', 'cookbook_artifacts_org_id_name_key', ARRAY['org_id', 'name']);
+
+  -- Keys
+  RETURN QUERY SELECT has_pk('cookbook_artifacts');
+  RETURN QUERY SELECT hasnt_fk('cookbook_artifacts');
+
+END;
+$$;

--- a/verify/cookbook_artifact_version_checksums.sql
+++ b/verify/cookbook_artifact_version_checksums.sql
@@ -1,0 +1,9 @@
+-- Verify cookbook_artifact_version_checksums
+
+BEGIN;
+
+SELECT cookbook_artifact_version_id, org_id, checksum
+FROM cookbook_artifact_version_checksums
+WHERE FALSE;
+
+ROLLBACK;

--- a/verify/cookbook_artifact_versions.sql
+++ b/verify/cookbook_artifact_versions.sql
@@ -1,0 +1,12 @@
+-- Verify cookbook_artifact_versions
+
+BEGIN;
+
+SELECT id, identifier,
+       meta_attributes, meta_long_desc,
+       metadata, serialized_object, updated_at,
+       created_at, last_updated_by, cookbook_id
+FROM cookbook_artifact_versions
+WHERE FALSE;
+
+ROLLBACK;

--- a/verify/cookbook_artifacts.sql
+++ b/verify/cookbook_artifacts.sql
@@ -1,0 +1,9 @@
+-- Verify cookbook_artifacts
+
+BEGIN;
+
+SELECT id, org_id, name, authz_id
+FROM cookbook_artifacts
+WHERE FALSE;
+
+ROLLBACK;


### PR DESCRIPTION
Mostly similar to the good old 'cookbook*' tables, but still different
enough to make them separate.
Also makes sense since we want this new endpoint's data completely
separate from the old one's.