### PR TITLE
Add `revision_id` column to policies

### DIFF
--- a/deploy/policies-revision-id.sql
+++ b/deploy/policies-revision-id.sql
@@ -1,0 +1,13 @@
+-- Deploy policies-revision-id
+-- requires: policies
+
+BEGIN;
+
+-- We have to nuke everything in order to be able to enforce NOT NULL on
+-- revision_id
+DELETE FROM policies;
+
+ALTER TABLE policies ADD COLUMN revision_id VARCHAR(255) NOT NULL;
+ALTER TABLE policies ADD CONSTRAINT unique_name_and_revision_id UNIQUE(org_id, name, revision_id);
+
+COMMIT;

--- a/deploy/policy_groups.sql
+++ b/deploy/policy_groups.sql
@@ -1,0 +1,29 @@
+-- Deploy policy_groups
+
+BEGIN;
+
+-- Based on release timing, this should be applied at the same time as
+-- `policies-revision-id`, which drops all rows from the policies table. Just
+-- to be extra extra certain, we do that again here. The alternative would be a
+-- data migration to create policy_groups rows for each unique policy_group in
+-- the policies table.
+DELETE FROM policies;
+
+ALTER TABLE policies DROP CONSTRAINT policies_name_group_org_id_key;
+ALTER TABLE policies DROP COLUMN policy_group CASCADE;
+
+CREATE TABLE IF NOT EXISTS policy_groups(
+  id VARCHAR(32) PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  authz_id CHAR(32) NOT NULL UNIQUE,
+  org_id CHAR(32) NOT NULL,
+  last_updated_by CHAR(32) NOT NULL,
+  serialized_object bytea,
+  CONSTRAINT policy_groups_name_org_id_key UNIQUE(name, org_id),
+  CONSTRAINT policies_org_id_fkey
+    FOREIGN KEY (org_id)
+    REFERENCES orgs(id)
+    ON DELETE CASCADE
+);
+
+COMMIT;

--- a/revert/policies-revision-id.sql
+++ b/revert/policies-revision-id.sql
@@ -1,0 +1,8 @@
+-- Revert policies-revision-id
+
+BEGIN;
+
+ALTER TABLE policies DROP COLUMN revision_id CASCADE;
+ALTER TABLE policies DROP CONSTRAINT unique_name_and_revision_id;
+
+COMMIT;

--- a/revert/policies-revision-id.sql
+++ b/revert/policies-revision-id.sql
@@ -2,7 +2,7 @@
 
 BEGIN;
 
-ALTER TABLE policies DROP COLUMN revision_id CASCADE;
 ALTER TABLE policies DROP CONSTRAINT unique_name_and_revision_id;
+ALTER TABLE policies DROP COLUMN revision_id CASCADE;
 
 COMMIT;

--- a/revert/policy_groups.sql
+++ b/revert/policy_groups.sql
@@ -1,0 +1,7 @@
+-- Revert policy_groups
+
+BEGIN;
+
+-- XXX Add DDLs here.
+
+COMMIT;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -68,3 +68,4 @@ keys_update_tracking [multiple_keys] 2015-02-24T18:57:08Z Marc Paradise <marc@ch
 @2.9.0 2015-02-24T18:57:42Z Marc Paradise <marc@chef.io># tag 2.9.0 for  keys update  tracking fields
 
 policies-revision-id [policies] 2015-02-26T22:54:21Z Daniel DeLeo <ddeleo@lorentz.local># Add revision_id column for policies
+policy_groups 2015-02-27T16:48:33Z Daniel DeLeo <ddeleo@lorentz.local># Create policy_groups as a separate table

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -66,3 +66,5 @@ delete_cookbook_artifact_version [cookbook_artifact_version_checksums] 2015-02-0
 
 keys_update_tracking [multiple_keys] 2015-02-24T18:57:08Z Marc Paradise <marc@chef.io># keys_update_tracking - add last_updated_by and updated_at fields to keys
 @2.9.0 2015-02-24T18:57:42Z Marc Paradise <marc@chef.io># tag 2.9.0 for  keys update  tracking fields
+
+policies-revision-id [policies] 2015-02-26T22:54:21Z Daniel DeLeo <ddeleo@lorentz.local># Add revision_id column for policies

--- a/t/test_policies_table.sql
+++ b/t/test_policies_table.sql
@@ -14,5 +14,8 @@ BEGIN
   RETURN QUERY SELECT fk_ok('policies', 'org_id', 'orgs', 'id');
   RETURN QUERY SELECT chef_pgtap.col_is_uuid('policies', 'last_updated_by');
   RETURN QUERY SELECT chef_pgtap.has_index('policies', 'policies_name_group_org_id_key', ARRAY['name', 'policy_group', 'org_id']);
+
+  RETURN QUERY SELECT col_type_is('policies', 'revision_id', 'character varying(255)');
+  RETURN QUERY SELECT col_is_unique('policies', ARRAY['org_id', 'name', 'revision_id']);
 END;
 $$

--- a/verify/policies-revision-id.sql
+++ b/verify/policies-revision-id.sql
@@ -1,0 +1,9 @@
+-- Verify policies-revision-id
+
+BEGIN;
+
+SELECT revision_id
+FROM policies
+WHERE FALSE;
+
+ROLLBACK;

--- a/verify/policy_groups.sql
+++ b/verify/policy_groups.sql
@@ -1,0 +1,7 @@
+-- Verify policy_groups
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
### :construction: Erchef Updates Incoming :construction: 

Adds a `revision_id` column to policies. Per the [draft spec](https://github.com/chef/chef-rfc/pull/91), this column is required, so it should be `NOT NULL`, but we can't add this constraint if there's any rows that violate it. Which means we either need to do a data migration or nuke the data. Given the status of the feature, I think it's acceptable to nuke.
